### PR TITLE
Feat: add disable grpc server when all config is done

### DIFF
--- a/cmd/elrs-joystick-control/main.go
+++ b/cmd/elrs-joystick-control/main.go
@@ -41,6 +41,9 @@ func main() {
 	disableWebUI := new(bool)
 	flag.BoolVar(disableWebUI, "disable-web-ui", false, "disable the Web-UI HTTP server")
 
+	disableGrpcServer := new(bool)
+	flag.BoolVar(disableGrpcServer, "disable-grpc-server", false, "disable the gRPC server")
+
 	flag.Parse()
 
 	grpcServer := grpc.NewServer([]grpc.ServerOption{}...)
@@ -81,5 +84,11 @@ func main() {
 		}
 	}()
 
-	serverCtl.Wait()
+	if *disableGrpcServer {
+		serverCtl.Stop()
+	} else {
+		serverCtl.Wait()
+	}
+
+	linkCtl.Wait()
 }

--- a/pkg/link/supervisor.go
+++ b/pkg/link/supervisor.go
@@ -39,6 +39,12 @@ func (c *Controller) StopSupervisor() error {
 	return nil
 }
 
+func (c *Controller) Wait() {
+	if err := c.supervisorTomb.Wait(); err != nil {
+		panic(err)
+	}
+}
+
 func action(action string, err error) {
 	if err != nil {
 		fmt.Printf("error while %s. %s", action, err.Error())


### PR DESCRIPTION
will close grpc after processing other parameters: 
```
elrs-joystick-control --tx-serial-port-name=COM3 --tx-serial-port-baud-rate=921600 --disable-grpc-server
```
=
```
elrs-joystick-control --tx-serial-port-name=COM3 --tx-serial-port-baud-rate=921600
```

then close gRPC server